### PR TITLE
KS-19-4-tank: Патроны для танка

### DIFF
--- a/src/main/kotlin/lesson_19/task_4/Main.kt
+++ b/src/main/kotlin/lesson_19/task_4/Main.kt
@@ -1,0 +1,53 @@
+package lesson_19.task_4
+
+fun main() {
+    val tank = Tank()
+
+    println("Пытаемся выстрелить не заряженным")
+    tank.shoot()
+    println()
+
+    println("Заряжаем красным типом патронов")
+    tank.chargeWeapons(Bullets.RED)
+    tank.shoot()
+    println()
+
+    println("Заряжаем зеленным типом патронов")
+    tank.chargeWeapons(Bullets.GREEN)
+    tank.shoot()
+    println()
+
+    println("Заряжаем синим типом патронов")
+    tank.chargeWeapons(Bullets.BLUE)
+    tank.shoot()
+}
+
+class Tank {
+    private var bullet: Bullets? = null
+
+    fun chargeWeapons(newBullet: Bullets?) {
+        bullet = newBullet
+        if (bullet == null) {
+            println("Я разряжен, не могу стрелять!")
+            return
+        }
+
+        println("Оружие заряжено типом патронов ${bullet?.name}")
+    }
+
+    fun shoot() {
+        if (bullet == null) {
+            println("Я не заряжен, не могу стрелять!")
+            return
+        }
+
+        println("Я стреляю ${bullet?.name} типом патронов, мой урон ${bullet?.power}")
+    }
+
+}
+
+enum class Bullets(var power: Int) {
+    BLUE(5),
+    GREEN(10),
+    RED(20)
+}


### PR DESCRIPTION
Что сделано:

В компьютерной игре танк может подбирать разные виды патронов. Патроны различаются силой удара. Синие – 5 единиц, зеленые – 10, красные – 20.

- [X] создай enum класс для патронов и класс танка. У танка должны быть методы вооружения новым типом патронов и выстрела. При выстреле в консоль должен выводиться нанесенный урон;
- [X] создай экземпляр танка и “произведи” несколько выстрелов разными патронами;
- [X] экземпляр танка при создании ничем не заряжен;
- [X] в решении должен использоваться enum.